### PR TITLE
Create real symlinks instead of creating shadow packages

### DIFF
--- a/src/FileSystemUtilities.js
+++ b/src/FileSystemUtilities.js
@@ -56,7 +56,7 @@ export default class FileSystemUtilities {
     fs.lstat(dest, (err) => {
       if (!err) {
         // Something exists at `dest`.  Need to remove it first.
-        fs.unlink(dest, () => fs.symlink(src, dest, callback));
+        rimraf(dest, () => fs.symlink(src, dest, callback));
       } else {
         fs.symlink(src, dest, callback);
       }

--- a/src/commands/BootstrapCommand.js
+++ b/src/commands/BootstrapCommand.js
@@ -6,7 +6,6 @@ import semver from "semver";
 import async from "async";
 import find from "lodash.find";
 import path from "path";
-import normalize from "normalize-path";
 
 export default class BootstrapCommand extends Command {
   initialize(callback) {
@@ -136,25 +135,7 @@ export default class BootstrapCommand extends Command {
   }
 
   createLinkedDependencyFiles(src, dest, name, callback) {
-    const srcPackageJsonLocation = path.join(src, "package.json");
-    const destPackageJsonLocation = path.join(dest, "package.json");
-    const destIndexJsLocation = path.join(dest, "index.js");
-
-    const packageJsonFileContents = JSON.stringify({
-      name: name,
-      version: require(srcPackageJsonLocation).version
-    }, null, "  ");
-
-    const prefix = this.repository.linkedFiles.prefix || "";
-    const indexJsFileContents = prefix + "module.exports = require(" +  JSON.stringify(normalize(src)) + ");";
-
-    FileSystemUtilities.writeFile(destPackageJsonLocation, packageJsonFileContents, (err) => {
-      if (err) {
-        return callback(err);
-      }
-
-      FileSystemUtilities.writeFile(destIndexJsLocation, indexJsFileContents, callback);
-    });
+    FileSystemUtilities.symlink(src, dest, callback);
   }
 
   linkBinariesForPackage(pkg, callback) {


### PR DESCRIPTION
<img width="494" alt="screen shot 2016-09-06 at 4 19 29 pm" src="https://cloud.githubusercontent.com/assets/4278113/18294535/b4f43418-744e-11e6-855d-14c4eb5efdc4.png">

^ The previous behavior would break any packages using something other than index file of a module. By creating real symlinks, we fix it
